### PR TITLE
Removed seeding of images in the web stage.

### DIFF
--- a/ubuntu-apache-compose/Dockerfile
+++ b/ubuntu-apache-compose/Dockerfile
@@ -47,9 +47,6 @@ RUN apt-get update && \
 COPY ./apache/conf/apache.conf /etc/apache2/sites-available/000-default.conf
 COPY ./apache/conf/security.conf /etc/apache2/conf-available/security.conf
 
-# Seed the web content
-COPY --from=content /seed/images/ /var/www/html/images/
-
 # Entrypoint script
 COPY ./shell/apache_start.sh /usr/local/bin/apache_start.sh
 RUN chmod +x /usr/local/bin/apache_start.sh


### PR DESCRIPTION
- The webroot (/var/www/html) is a shared named volume (wwwdata) mounted into both containers. 
- Anything baked into the web image’s filesystem layer at /var/www/html will be hidden once the volume mounts at runtime. 
- The samba_start.sh intentionally seeds from /seed into /srv/www/html on every Samba container start, ensuring the volume always has the desired content and correct ownership/ACLs.